### PR TITLE
Expand Pty.Net platform support

### DIFF
--- a/azure-pipelines/build-openconsole.yml
+++ b/azure-pipelines/build-openconsole.yml
@@ -1,12 +1,3 @@
-steps:
-- task: VSBuild@1
-  displayName: 'Build OpenConsole x86'
-  inputs:
-    solution: 'dep/terminal/OpenConsole.sln'
-    msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE
-    platform: 'x86'
-    configuration: '$(BuildConfiguration)'
-
 - task: VSBuild@1
   displayName: 'Build OpenConsole x64'
   inputs:
@@ -16,7 +7,7 @@ steps:
     configuration: '$(BuildConfiguration)'
 
 - task: VSBuild@1
-  displayName: 'Build OpenConsole '
+  displayName: 'Build OpenConsole Arm64'
   inputs:
     solution: 'dep/terminal/OpenConsole.sln'
     msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE

--- a/azure-pipelines/build-openconsole.yml
+++ b/azure-pipelines/build-openconsole.yml
@@ -1,3 +1,4 @@
+steps:
 - task: VSBuild@1
   displayName: 'Build OpenConsole x64'
   inputs:
@@ -11,5 +12,5 @@
   inputs:
     solution: 'dep/terminal/OpenConsole.sln'
     msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE
-    platform: 'Arm64'
+    platform: 'rm64'
     configuration: '$(BuildConfiguration)'

--- a/azure-pipelines/build-openconsole.yml
+++ b/azure-pipelines/build-openconsole.yml
@@ -1,12 +1,19 @@
 steps:
 - task: VSBuild@1
+  displayName: 'Build OpenConsole x86'
+  inputs:
+    solution: 'dep/terminal/OpenConsole.sln'
+    msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE
+    platform: 'x86'
+    configuration: '$(BuildConfiguration)'
+
+- task: VSBuild@1
   displayName: 'Build OpenConsole x64'
   inputs:
     solution: 'dep/terminal/OpenConsole.sln'
     msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE
     platform: 'x64'
     configuration: '$(BuildConfiguration)'
-
 - task: VSBuild@1
   displayName: 'Build OpenConsole Arm64'
   inputs:

--- a/azure-pipelines/build-openconsole.yml
+++ b/azure-pipelines/build-openconsole.yml
@@ -12,5 +12,5 @@ steps:
   inputs:
     solution: 'dep/terminal/OpenConsole.sln'
     msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE
-    platform: 'rm64'
+    platform: 'Arm64'
     configuration: '$(BuildConfiguration)'

--- a/azure-pipelines/build-openconsole.yml
+++ b/azure-pipelines/build-openconsole.yml
@@ -1,6 +1,6 @@
 steps:
 - task: VSBuild@1
-  displayName: 'Build OpenConsole'
+  displayName: 'Build OpenConsole x86'
   inputs:
     solution: 'dep/terminal/OpenConsole.sln'
     msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE
@@ -8,9 +8,17 @@ steps:
     configuration: '$(BuildConfiguration)'
 
 - task: VSBuild@1
-  displayName: 'Build OpenConsole'
+  displayName: 'Build OpenConsole x64'
   inputs:
     solution: 'dep/terminal/OpenConsole.sln'
     msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE
     platform: 'x64'
+    configuration: '$(BuildConfiguration)'
+
+- task: VSBuild@1
+  displayName: 'Build OpenConsole '
+  inputs:
+    solution: 'dep/terminal/OpenConsole.sln'
+    msbuildArgs: /t:Conhost\winconpty_DLL;Conhost\Host_EXE
+    platform: 'Arm64'
     configuration: '$(BuildConfiguration)'

--- a/azure-pipelines/build-winpty.yml
+++ b/azure-pipelines/build-winpty.yml
@@ -10,8 +10,5 @@ steps:
 - script: echo $PATH
   displayName: Print PATH
 
-- script: dep/winpty/vcbuild.bat --msvc-platform Win32 --toolset v142 --gyp-msvs-version 2017
-  displayName: Build x86 winpty
-
 - script: dep/winpty/vcbuild.bat --msvc-platform x64 --toolset v142 --gyp-msvs-version 2017
   displayName: Build x64 winpty

--- a/azure-pipelines/build-winpty.yml
+++ b/azure-pipelines/build-winpty.yml
@@ -1,9 +1,9 @@
 steps:
-# - task: UsePythonVersion@0 
-#   inputs:
-#     versionSpec: 3.6
-#     addToPath: true
-#     architecture: x64
+- task: UsePythonVersion@0 
+  inputs:
+    versionSpec: 3.6.8
+    addToPath: true
+    architecture: x64
 
 - powershell: azure-pipelines/Set-MSBuildPath.ps1
 

--- a/azure-pipelines/build-winpty.yml
+++ b/azure-pipelines/build-winpty.yml
@@ -1,7 +1,7 @@
 steps:
 - task: UsePythonVersion@0 
   inputs:
-    versionSpec: 3.6.8
+    versionSpec: 3.9
     addToPath: true
     architecture: x64
 

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -45,7 +45,7 @@ jobs:
   - Linux
   - MacOS
   pool:
-    vmImage: Ubuntu 16.04
+    vmImage: Ubuntu 18.04
   condition: succeededOrFailed()
   steps:
   - checkout: self

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -9,7 +9,7 @@ jobs:
   - script: .\nbgv cloud -p src
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
     - template: microbuild.before.yml
-  - template: build-winpty.yml
+#  - template: build-winpty.yml
   - template: build-openconsole.yml
   - template: msbuild.yml
   - template: publish.yml

--- a/src/OSS.Sign/OSS.Sign.csproj
+++ b/src/OSS.Sign/OSS.Sign.csproj
@@ -11,22 +11,44 @@
 
   <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
     <ItemGroup>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
+      <!-- Release build ConPty files -->
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Release'">
         <PackagePath>x86</PackagePath>
       </OpenConsoleFiles>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Release'">
         <PackagePath>x86</PackagePath>
       </OpenConsoleFiles>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Release'">
         <PackagePath>x64</PackagePath>
       </OpenConsoleFiles>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Release'">
         <PackagePath>x64</PackagePath>
       </OpenConsoleFiles>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Release'">
         <PackagePath>Arm64</PackagePath>
       </OpenConsoleFiles>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Release'">
+        <PackagePath>Arm64</PackagePath>
+      </OpenConsoleFiles>
+    </ItemGroup>
+    <ItemGroup>
+      <!-- Debug build ConPty files -->
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Debug\conpty.dll" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Debug'">
+        <PackagePath>x86</PackagePath>
+      </OpenConsoleFiles>
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Debug\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Debug'">
+        <PackagePath>x86</PackagePath>
+      </OpenConsoleFiles>
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Debug\conpty.dll" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Debug'">
+        <PackagePath>x64</PackagePath>
+      </OpenConsoleFiles>
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Debug\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Debug'">
+        <PackagePath>x64</PackagePath>
+      </OpenConsoleFiles>
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Debug\conpty.dll" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Debug'">
+        <PackagePath>Arm64</PackagePath>
+      </OpenConsoleFiles>
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Debug\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath)) And '$(Configuration)'=='Debug'">
         <PackagePath>Arm64</PackagePath>
       </OpenConsoleFiles>
     </ItemGroup>

--- a/src/OSS.Sign/OSS.Sign.csproj
+++ b/src/OSS.Sign/OSS.Sign.csproj
@@ -24,7 +24,7 @@
         <PackagePath>x64</PackagePath>
       </OpenConsoleFiles>
     </ItemGroup>
-    <ItemGroup>
+    <!--<ItemGroup>
       <WinPtyFiles Include="$(WinptyReleasePath)\Win32\winpty.dll" Condition="Exists($(WinptyReleasePath))">
         <PackagePath>x86</PackagePath>
       </WinPtyFiles>
@@ -37,8 +37,8 @@
       <WinPtyFiles Include="$(WinptyReleasePath)\x64\winpty-agent.exe" Condition="Exists($(WinptyReleasePath))">
         <PackagePath>x64</PackagePath>
       </WinPtyFiles>
-    </ItemGroup>
-    <Copy SourceFiles="@(WinPtyFiles)" DestinationFolder="$(OutputPath)\winpty\%(WinPtyFiles.PackagePath)" />
+    </ItemGroup>-->
+    <!--<Copy SourceFiles="@(WinPtyFiles)" DestinationFolder="$(OutputPath)\winpty\%(WinPtyFiles.PackagePath)" />-->
     <Copy SourceFiles="@(OpenConsoleFiles)" DestinationFolder="$(OutputPath)\conpty\%(OpenConsoleFiles.PackagePath)" />
   </Target>
 
@@ -58,10 +58,10 @@
 
   <Target Name="CopySignedFiles" AfterTargets="Build">
     <ItemGroup>
-      <SignedWinPty Include="$(OutputPath)\winpty\**\*" />
+      <!--<SignedWinPty Include="$(OutputPath)\winpty\**\*" />-->
       <SignedOpenConsole Include="$(OutputPath)\conpty\**\*" />
     </ItemGroup>
-    <Copy SourceFiles="@(SignedWinPty)" DestinationFolder="$(RepoRootPath)\bin\winpty\%(SignedWinPty.RecursiveDir)" />
+    <!--<Copy SourceFiles="@(SignedWinPty)" DestinationFolder="$(RepoRootPath)\bin\winpty\%(SignedWinPty.RecursiveDir)" />-->
     <Copy SourceFiles="@(SignedOpenConsole)" DestinationFolder="$(RepoRootPath)\bin\conpty\%(SignedOpenConsole.RecursiveDir)" />
   </Target>
 </Project>

--- a/src/OSS.Sign/OSS.Sign.csproj
+++ b/src/OSS.Sign/OSS.Sign.csproj
@@ -24,10 +24,10 @@
         <PackagePath>x64</PackagePath>
       </OpenConsoleFiles>
       <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
-        <PackagePath>x64</PackagePath>
+        <PackagePath>Arm64</PackagePath>
       </OpenConsoleFiles>
       <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
-        <PackagePath>x64</PackagePath>
+        <PackagePath>Arm64</PackagePath>
       </OpenConsoleFiles>
     </ItemGroup>
     <!--<ItemGroup>

--- a/src/OSS.Sign/OSS.Sign.csproj
+++ b/src/OSS.Sign/OSS.Sign.csproj
@@ -11,12 +11,12 @@
 
   <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
     <ItemGroup>
-      <!--<OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
         <PackagePath>x86</PackagePath>
       </OpenConsoleFiles>
       <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
         <PackagePath>x86</PackagePath>
-      </OpenConsoleFiles>-->
+      </OpenConsoleFiles>
       <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
         <PackagePath>x64</PackagePath>
       </OpenConsoleFiles>

--- a/src/OSS.Sign/OSS.Sign.csproj
+++ b/src/OSS.Sign/OSS.Sign.csproj
@@ -11,16 +11,22 @@
 
   <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
     <ItemGroup>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
+      <!--<OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
         <PackagePath>x86</PackagePath>
       </OpenConsoleFiles>
       <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\Win32\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
         <PackagePath>x86</PackagePath>
-      </OpenConsoleFiles>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\x64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
+      </OpenConsoleFiles>-->
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
         <PackagePath>x64</PackagePath>
       </OpenConsoleFiles>
-      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)\x64\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)x64\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
+        <PackagePath>x64</PackagePath>
+      </OpenConsoleFiles>
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Release\conpty.dll" Condition="Exists($(OpenConsoleReleasePath))">
+        <PackagePath>x64</PackagePath>
+      </OpenConsoleFiles>
+      <OpenConsoleFiles Include="$(OpenConsoleReleasePath)Arm64\Release\OpenConsole.exe" Condition="Exists($(OpenConsoleReleasePath))">
         <PackagePath>x64</PackagePath>
       </OpenConsoleFiles>
     </ItemGroup>

--- a/src/Pty.Net/Pty.Net.csproj
+++ b/src/Pty.Net/Pty.Net.csproj
@@ -5,15 +5,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(WinptyReleasePath)\x64\*.dll;$(WinptyReleasePath)\x64\*.exe">
+    <!--<None Include="$(WinptyReleasePath)\x64\*.dll;$(WinptyReleasePath)\x64\*.exe">
       <Visible>false</Visible>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </None>-->
 
     <None Include="$(OpenConsoleReleasePath)\x64\Release\*.dll;$(OpenConsoleReleasePath)\x64\Release\*.exe">
       <Visible>false</Visible>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <LinkBase>os64\</LinkBase>
+    </None>
+
+    <None Include="$(OpenConsoleReleasePath)\Arm64\Release\*.dll;$(OpenConsoleReleasePath)\Arm64\Release\*.exe">
+      <Visible>false</Visible>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <LinkBase>arm64\</LinkBase>
     </None>
 
     <None Include="Pty.Net.targets">
@@ -30,7 +36,7 @@
 
   <Target Name="CollectNugetFiles" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
-      <OutputPtyFiles Include="$(RepoRootPath)\bin\winpty\**\*" />
+      <!--<OutputPtyFiles Include="$(RepoRootPath)\bin\winpty\**\*" />-->
       
       <None Include="@(OutputPtyFiles)">
         <Pack>true</Pack>

--- a/src/Pty.Net/Pty.Net.csproj
+++ b/src/Pty.Net/Pty.Net.csproj
@@ -37,6 +37,7 @@
         <PackagePath>build\</PackagePath>
       </None>
 
+      <!-- x86 version of ConPty and OpenConsole -->
       <None Include="$(RepoRootPath)\bin\conpty\x86\conpty.dll">
         <Pack>true</Pack>
         <PackagePath>build\x86\os86</PackagePath>
@@ -54,6 +55,7 @@
         <PackagePath>build\x86\os64</PackagePath>
       </None>
 
+      <!-- x64 version of ConPty and OpenConsole -->
       <None Include="$(RepoRootPath)\bin\conpty\x64\conpty.dll">
         <Pack>true</Pack>
         <PackagePath>build\x64\os86</PackagePath>
@@ -69,6 +71,16 @@
       <None Include="$(RepoRootPath)\bin\conpty\x64\OpenConsole.exe">
         <Pack>true</Pack>
         <PackagePath>build\x64\os64</PackagePath>
+      </None>
+
+      <!-- Arm64 version of ConPty and OpenConsole -->
+      <None Include="$(RepoRootPath)\bin\conpty\Arm64\conpty.dll">
+        <Pack>true</Pack>
+        <PackagePath>build\x64\arm64</PackagePath>
+      </None>
+      <None Include="$(RepoRootPath)\bin\conpty\Arm64\OpenConsole.exe">
+        <Pack>true</Pack>
+        <PackagePath>build\x64\arm64</PackagePath>
       </None>
     </ItemGroup>
   </Target>

--- a/src/Pty.Net/Pty.Net.csproj
+++ b/src/Pty.Net/Pty.Net.csproj
@@ -44,7 +44,7 @@
       </None>
 
       <!-- x86 version of ConPty and OpenConsole -->
-      <None Include="$(RepoRootPath)\bin\conpty\x86\conpty.dll">
+      <!--<None Include="$(RepoRootPath)\bin\conpty\x86\conpty.dll">
         <Pack>true</Pack>
         <PackagePath>build\x86\os86</PackagePath>
       </None>
@@ -59,7 +59,7 @@
       <None Include="$(RepoRootPath)\bin\conpty\x64\OpenConsole.exe">
         <Pack>true</Pack>
         <PackagePath>build\x86\os64</PackagePath>
-      </None>
+      </None>-->
 
       <!-- x64 version of ConPty and OpenConsole -->
       <None Include="$(RepoRootPath)\bin\conpty\x64\conpty.dll">
@@ -70,10 +70,10 @@
         <Pack>true</Pack>
         <PackagePath>build\x64\os64</PackagePath>
       </None>
-      <None Include="$(RepoRootPath)\bin\conpty\x86\OpenConsole.exe">
+      <!--<None Include="$(RepoRootPath)\bin\conpty\x86\OpenConsole.exe">
         <Pack>true</Pack>
         <PackagePath>build\x64\os86</PackagePath>
-      </None>
+      </None>-->
       <None Include="$(RepoRootPath)\bin\conpty\x64\OpenConsole.exe">
         <Pack>true</Pack>
         <PackagePath>build\x64\os64</PackagePath>

--- a/src/Pty.Net/Pty.Net.csproj
+++ b/src/Pty.Net/Pty.Net.csproj
@@ -44,7 +44,7 @@
       </None>
 
       <!-- x86 version of ConPty and OpenConsole -->
-      <!--<None Include="$(RepoRootPath)\bin\conpty\x86\conpty.dll">
+      <None Include="$(RepoRootPath)\bin\conpty\x86\conpty.dll">
         <Pack>true</Pack>
         <PackagePath>build\x86\os86</PackagePath>
       </None>
@@ -59,7 +59,7 @@
       <None Include="$(RepoRootPath)\bin\conpty\x64\OpenConsole.exe">
         <Pack>true</Pack>
         <PackagePath>build\x86\os64</PackagePath>
-      </None>-->
+      </None>
 
       <!-- x64 version of ConPty and OpenConsole -->
       <None Include="$(RepoRootPath)\bin\conpty\x64\conpty.dll">
@@ -70,10 +70,10 @@
         <Pack>true</Pack>
         <PackagePath>build\x64\os64</PackagePath>
       </None>
-      <!--<None Include="$(RepoRootPath)\bin\conpty\x86\OpenConsole.exe">
+      <None Include="$(RepoRootPath)\bin\conpty\x86\OpenConsole.exe">
         <Pack>true</Pack>
         <PackagePath>build\x64\os86</PackagePath>
-      </None>-->
+      </None>
       <None Include="$(RepoRootPath)\bin\conpty\x64\OpenConsole.exe">
         <Pack>true</Pack>
         <PackagePath>build\x64\os64</PackagePath>

--- a/src/Pty.Net/Pty.Net.csproj
+++ b/src/Pty.Net/Pty.Net.csproj
@@ -10,6 +10,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>-->
 
+    <None Include="$(OpenConsoleReleasePath)\x86\Release\*.dll;$(OpenConsoleReleasePath)\x86\Release\*.exe">
+      <Visible>false</Visible>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <LinkBase>os86\</LinkBase>
+    </None>
+    
     <None Include="$(OpenConsoleReleasePath)\x64\Release\*.dll;$(OpenConsoleReleasePath)\x64\Release\*.exe">
       <Visible>false</Visible>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -38,10 +44,10 @@
     <ItemGroup>
       <!--<OutputPtyFiles Include="$(RepoRootPath)\bin\winpty\**\*" />-->
       
-      <None Include="@(OutputPtyFiles)">
+      <!-- <None Include="@(OutputPtyFiles)">
         <Pack>true</Pack>
         <PackagePath>build\</PackagePath>
-      </None>
+      </None> -->
 
       <!-- x86 version of ConPty and OpenConsole -->
       <None Include="$(RepoRootPath)\bin\conpty\x86\conpty.dll">
@@ -82,11 +88,11 @@
       <!-- Arm64 version of ConPty and OpenConsole -->
       <None Include="$(RepoRootPath)\bin\conpty\Arm64\conpty.dll">
         <Pack>true</Pack>
-        <PackagePath>build\x64\arm64</PackagePath>
+        <PackagePath>build\arm64</PackagePath>
       </None>
       <None Include="$(RepoRootPath)\bin\conpty\Arm64\OpenConsole.exe">
         <Pack>true</Pack>
-        <PackagePath>build\x64\arm64</PackagePath>
+        <PackagePath>build\arm64</PackagePath>
       </None>
     </ItemGroup>
   </Target>

--- a/src/Pty.Net/Pty.Net.targets
+++ b/src/Pty.Net/Pty.Net.targets
@@ -1,15 +1,15 @@
 ﻿<Project>
   <ItemGroup>
     <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'x64'">
-      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os86\*" />
-      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
+      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os86\*" />
+      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
     </ConPtyFiles>
     <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'x86'">
-      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os86\*" />
-      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
+      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os86\*" />
+      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
     </ConPtyFiles>
     <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'arm64'">
-      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\Arm64\*" />
+      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\Arm64\*" />
     </ConPtyFiles>
   </ItemGroup>
   

--- a/src/Pty.Net/Pty.Net.targets
+++ b/src/Pty.Net/Pty.Net.targets
@@ -1,7 +1,16 @@
 ﻿<Project>
   <ItemGroup>
-    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' != 'AnyCPU'" 
-                 Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\**\*" />
+    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'x64'">
+      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os86\*" />
+      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
+    </ConPtyFiles>
+    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'x86'">
+      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os86\*" />
+      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
+    </ConPtyFiles>
+    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'arm64'">
+      <Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\Arm64\*" />
+    </ConPtyFiles>
   </ItemGroup>
   
   <Target Name="CopyPtyNativeFiles">

--- a/src/Pty.Net/Pty.Net.targets
+++ b/src/Pty.Net/Pty.Net.targets
@@ -1,16 +1,11 @@
 ﻿<Project>
   <ItemGroup>
-    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'x64'">
-      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os86\*" />
-      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
-    </ConPtyFiles>
-    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'x86'">
-      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os86\*" />
-      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
-    </ConPtyFiles>
-    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'arm64'">
-      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\*" />
-    </ConPtyFiles>
+    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'x64'" 
+                 Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\**\*" />
+    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'x86'"
+                 Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\**\*" />
+    <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'Arm64'"
+                 Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)*" />
   </ItemGroup>
   
   <Target Name="CopyPtyNativeFiles">

--- a/src/Pty.Net/Pty.Net.targets
+++ b/src/Pty.Net/Pty.Net.targets
@@ -9,7 +9,7 @@
       <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\os64\*" />
     </ConPtyFiles>
     <ConPtyFiles Condition="'$(PlatformTarget)' != '' And '$(PlatformTarget)' == 'arm64'">
-      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\Arm64\*" />
+      <None Include="$(MSBuildThisFileDirectory)\$(PlatformTarget)\*" />
     </ConPtyFiles>
   </ItemGroup>
   

--- a/src/Pty.Net/Windows/NativeMethods.cs
+++ b/src/Pty.Net/Windows/NativeMethods.cs
@@ -78,37 +78,43 @@ namespace Pty.Net.Windows
 
         internal static int CreatePseudoConsole(Coord coord, IntPtr input, IntPtr output, uint flags, out IntPtr consoleHandle)
         {
-            if (Environment.Is64BitOperatingSystem)
+            switch (RuntimeInformation.ProcessArchitecture)
             {
-                return CreatePseudoConsole64(coord, input, output, flags, out consoleHandle);
-            }
-            else
-            {
-                return CreatePseudoConsole86(coord, input, output, flags, out consoleHandle);
+                case Architecture.Arm64:
+                    return CreatePseudoConsoleArm64(coord, input, output, flags, out consoleHandle);
+                case Architecture.X64:
+                    return CreatePseudoConsole64(coord, input, output, flags, out consoleHandle);
+                default:
+                    return CreatePseudoConsole86(coord, input, output, flags, out consoleHandle);
             }
         }
 
         internal static int ResizePseudoConsole(SafePseudoConsoleHandle consoleHandle, Coord coord)
         {
-            if (Environment.Is64BitOperatingSystem)
+            switch (RuntimeInformation.ProcessArchitecture)
             {
-                return ResizePseudoConsole64(consoleHandle, coord);
-            }
-            else
-            {
-                return ResizePseudoConsole86(consoleHandle, coord);
+                case Architecture.Arm64:
+                    return ResizePseudoConsoleArm64(consoleHandle, coord);
+                case Architecture.X64:
+                    return ResizePseudoConsole64(consoleHandle, coord);
+                default:
+                    return ResizePseudoConsole86(consoleHandle, coord);
             }
         }
 
         internal static void ClosePseudoConsole(IntPtr consoleHandle)
         {
-            if (Environment.Is64BitOperatingSystem)
+            switch (RuntimeInformation.ProcessArchitecture)
             {
-                ClosePseudoConsole64(consoleHandle);
-            }
-            else
-            {
-                ClosePseudoConsole86(consoleHandle);
+                case Architecture.Arm64:
+                    ClosePseudoConsoleArm64(consoleHandle);
+                    break;
+                case Architecture.X64:
+                    ClosePseudoConsole64(consoleHandle);
+                    break;
+                default:
+                    ClosePseudoConsole86(consoleHandle);
+                    break;
             }
         }
 
@@ -126,6 +132,17 @@ namespace Pty.Net.Windows
 
         [DllImport("kernel32.dll")]
         internal static extern IntPtr GetProcAddress(IntPtr hModule, [MarshalAs(UnmanagedType.LPStr)] string procName);
+
+        [DllImport("arm64\\conpty.dll", EntryPoint = "CreatePseudoConsole")]
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        private static extern int CreatePseudoConsoleArm64(Coord coord, IntPtr input, IntPtr output, uint flags, out IntPtr consoleHandle);
+
+        [DllImport("arm64\\conpty.dll", EntryPoint = "ResizePseudoConsole")]
+        private static extern int ResizePseudoConsoleArm64(SafePseudoConsoleHandle consoleHandle, Coord coord);
+
+        [DllImport("arm64\\conpty.dll", EntryPoint = "ClosePseudoConsole")]
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        private static extern void ClosePseudoConsoleArm64(IntPtr consoleHandle);
 
         [DllImport("os64\\conpty.dll", EntryPoint = "CreatePseudoConsole")]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]


### PR DESCRIPTION
Linux systems can be run in ARM CPU architectures and Pty.Net currently doesn't support multi-platform targets. 

This PR adds more smart switches for identifying the target platform and providing the right binaries for the platform